### PR TITLE
Add Origin class

### DIFF
--- a/build_library.sh
+++ b/build_library.sh
@@ -10,7 +10,33 @@ echo "-- SCROLL TO BOTTOM ----------------------------------------------------\n
 find . -name '*.lua' -not -name 'library.lua' -not -name 'builtins.lua' -not -name 'temp_library.lua' -exec sh -c 'cat {} && echo && echo' \; >> "$temp_file"
 
 # Add the bottom content
-echo -e "-- AUDULUS-CANVAS LIBRARY ----------------------------------------------\n\n----- Instructions -----\n-- 1. Create 'Time' input (case-sensitive)\n-- 2. Attach Timer node to the 'Time' input\n-- 3. Select 'Save Data' at the bottom of the inspector panel\n-- 4. Set a custom W(idth) and H(eight) in the inspector panel\n-- 5. Write your code below this line\n\n-- CODE ----------------------------------------------------------------\n\n\n\n\n\n-- PRINT CONSOLE -------------------------------------------------------\n\nprint_all()" >> "$temp_file"
+echo -e "
+-- AUDULUS-CANVAS LIBRARY ----------------------------------------------
+-- Version: 0.0.2-alpha
+-- Updated: 2023.12.26
+-- URL: https://github.com/markalanboyd/Audulus-Canvas
+
+----- Instructions -----
+-- 1. Create 'Time' input (case-sensitive)
+-- 2. Attach Timer node to the 'Time' input
+-- 3. Select 'Save Data' at the bottom of the inspector panel
+-- 4. Set a custom W(idth) and H(eight) in the inspector panel
+-- 5. Write your code in the CODE block below
+
+o = Origin.new(\"c\", {show = true, type = \"cross\", width = 4, color = theme.text})
+
+-- CODE ----------------------------------------------------------------
+
+
+
+
+
+
+-- PRINT CONSOLE -------------------------------------------------------
+
+o:reset()
+print_all()
+" >> "$temp_file"
 
 # Rename the temporary file to library.lua
 mv "$temp_file" "library.lua"

--- a/library.lua
+++ b/library.lua
@@ -318,6 +318,65 @@ function Point:draw()
 end
 
 
+Origin = {}
+Origin.__index = Origin
+
+function Origin.new(direction, options)
+    local self = setmetatable({}, Origin)
+    local o = options or {}
+
+    self.direction = direction or "sw"
+    self.show = o.show or false
+    self.type = string.lower(o.type) or "stroke"
+    self.width = o.width or 4
+    self.color = o.color or theme.text
+    self.offset = self.calculate_offset(direction)
+
+    translate(self.offset)
+
+    if self.show then
+        local paint = color_paint(self.color)
+        if self.type == "stroke" or self.type == "outline" then
+            stroke_circle({ 0, 0 }, self.width, 1, paint)
+        elseif self.type == "fill" or self.type == "dot" then
+            fill_circle({ 0, 0 }, self.width, paint)
+        elseif self.type == "+" or self.type == "cross" then
+            stroke_segment({ 0, -self.width }, { 0, self.width }, 1, paint)
+            stroke_segment({ -self.width, 0 }, { self.width, 0 }, 1, paint)
+        end
+    end
+
+    return self
+end
+
+function Origin.calculate_offset(direction)
+    local w = canvas_width
+    local h = canvas_height
+    local hw = w / 2
+    local hh = h / 2
+    local origin_offsets = {
+        sw = { 0, 0 },
+        w  = { 0, hh },
+        nw = { 0, h },
+        n  = { hw, h },
+        ne = { w, h },
+        e  = { w, hh },
+        se = { w, 0 },
+        s  = { hw, 0 },
+        c  = { hw, hw }
+    }
+    local offset = origin_offsets[string.lower(direction)]
+    if type(offset) == nil then
+        error("Invalid direction. Must be 'n', 'ne', 'e', 'se', 's', 'sw', 'w', or 'nw'")
+    end
+    return offset
+end
+
+function Origin:reset()
+    translate { -self.offset[1], -self.offset[2] }
+end
+
+
 Triangle = {}
 Triangle.__index = Triangle
 
@@ -861,14 +920,20 @@ function Graph:draw()
 end
 
 
+
 -- AUDULUS-CANVAS LIBRARY ----------------------------------------------
+-- Version: 0.0.2-alpha
+-- Updated: 2023.12.26
+-- URL: https://github.com/markalanboyd/Audulus-Canvas
 
 ----- Instructions -----
 -- 1. Create 'Time' input (case-sensitive)
 -- 2. Attach Timer node to the 'Time' input
 -- 3. Select 'Save Data' at the bottom of the inspector panel
 -- 4. Set a custom W(idth) and H(eight) in the inspector panel
--- 5. Write your code below this line
+-- 5. Write your code in the CODE block below
+
+o = Origin.new("c", {show = true, type = "cross", width = 4, color = theme.text})
 
 -- CODE ----------------------------------------------------------------
 
@@ -876,6 +941,9 @@ end
 
 
 
+
 -- PRINT CONSOLE -------------------------------------------------------
 
+o:reset()
 print_all()
+

--- a/src/draw/Origin.lua
+++ b/src/draw/Origin.lua
@@ -1,0 +1,57 @@
+Origin = {}
+Origin.__index = Origin
+
+function Origin.new(direction, options)
+    local self = setmetatable({}, Origin)
+    local o = options or {}
+
+    self.direction = direction or "sw"
+    self.show = o.show or false
+    self.type = string.lower(o.type) or "stroke"
+    self.width = o.width or 4
+    self.color = o.color or theme.text
+    self.offset = self.calculate_offset(direction)
+
+    translate(self.offset)
+
+    if self.show then
+        local paint = color_paint(self.color)
+        if self.type == "stroke" or self.type == "outline" then
+            stroke_circle({ 0, 0 }, self.width, 1, paint)
+        elseif self.type == "fill" or self.type == "dot" then
+            fill_circle({ 0, 0 }, self.width, paint)
+        elseif self.type == "+" or self.type == "cross" then
+            stroke_segment({ 0, -self.width }, { 0, self.width }, 1, paint)
+            stroke_segment({ -self.width, 0 }, { self.width, 0 }, 1, paint)
+        end
+    end
+
+    return self
+end
+
+function Origin.calculate_offset(direction)
+    local w = canvas_width
+    local h = canvas_height
+    local hw = w / 2
+    local hh = h / 2
+    local origin_offsets = {
+        sw = { 0, 0 },
+        w  = { 0, hh },
+        nw = { 0, h },
+        n  = { hw, h },
+        ne = { w, h },
+        e  = { w, hh },
+        se = { w, 0 },
+        s  = { hw, 0 },
+        c  = { hw, hw }
+    }
+    local offset = origin_offsets[string.lower(direction)]
+    if type(offset) == nil then
+        error("Invalid direction. Must be 'n', 'ne', 'e', 'se', 's', 'sw', 'w', or 'nw'")
+    end
+    return offset
+end
+
+function Origin:reset()
+    translate { -self.offset[1], -self.offset[2] }
+end


### PR DESCRIPTION
The Origin class allows you to set the origin of the canvas node relative to cardinal directions. Updates the library.lua template so that the origin is instantiated and then reset before print_all() is called.

Resolves #59 